### PR TITLE
Add tests for indicators and market clock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the Python path for absolute imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+
+from app.core.indicators import ema, vwap, atr
+
+
+def test_ema_simple_series():
+    series = pd.Series([1, 2, 3, 4, 5], dtype=float)
+    result = ema(series, length=3)
+    expected = pd.Series([1.0, 1.5, 2.25, 3.125, 4.0625])
+    np.testing.assert_allclose(result.values, expected.values)
+
+
+def test_vwap_simple_dataframe():
+    df = pd.DataFrame(
+        {
+            "close": [10, 20, 30],
+            "high": [12, 22, 32],
+            "low": [8, 18, 28],
+            "volume": [100, 200, 300],
+        }
+    )
+    result = vwap(df)
+    expected = pd.Series([10.0, 5000 / 300, 14000 / 600])
+    np.testing.assert_allclose(result.values, expected.values)
+
+
+def test_atr_simple_dataframe():
+    df = pd.DataFrame(
+        {
+            "high": [10, 15, 20, 18],
+            "low": [5, 10, 12, 14],
+            "close": [8, 12, 16, 17],
+        }
+    )
+    result = atr(df, length=3)
+    assert np.isnan(result.iloc[0])
+    assert np.isnan(result.iloc[1])
+    np.testing.assert_allclose(result.iloc[2:].values, np.array([20 / 3, 19 / 3]))

--- a/tests/test_market_clock.py
+++ b/tests/test_market_clock.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.core.market_clock import is_market_open
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def test_is_market_open_during_hours():
+    dt = datetime(2023, 6, 5, 10, 0, tzinfo=IST)  # Monday
+    assert is_market_open(dt) is True
+
+
+def test_is_market_open_weekend():
+    dt = datetime(2023, 6, 3, 10, 0, tzinfo=IST)  # Saturday
+    assert is_market_open(dt) is False
+
+
+def test_is_market_open_after_hours():
+    dt = datetime(2023, 6, 5, 16, 0, tzinfo=IST)  # Monday after close
+    assert is_market_open(dt) is False


### PR DESCRIPTION
## Summary
- add conftest to expose repository root for imports
- test EMA, VWAP, and ATR indicator calculations using deterministic data
- verify market opening logic across trading hours and weekends

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68987eb451d0832ab4960701ad360542